### PR TITLE
Add apiserver_request_total metric to the aggregate prometheus instance

### DIFF
--- a/pkg/component/observability/monitoring/prometheus/aggregate/scrapeconfigs_test.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/scrapeconfigs_test.go
@@ -32,6 +32,7 @@ var _ = Describe("ScrapeConfigs", func() {
 								`{job="kube-state-metrics",namespace=""}`,
 								`{job="cadvisor",namespace=~"garden|extension-.+"}`,
 								`{job="etcd-druid",namespace="garden"}`,
+								`{__name__="apiserver_request_total"}`,
 							},
 						},
 						KubernetesSDConfigs: []monitoringv1alpha1.KubernetesSDConfig{{

--- a/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
+++ b/pkg/component/observability/monitoring/prometheus/aggregate/servicemonitors.go
@@ -39,6 +39,7 @@ func CentralServiceMonitors() []*monitoringv1.ServiceMonitor {
 							`{__name__="prometheus_tsdb_storage_blocks_bytes"}`,
 							`{__name__="kubeproxy_network_latency:quantile"}`,
 							`{__name__="kubeproxy_sync_proxy:quantile"}`,
+							`{__name__="apiserver_request_total"}`,
 						},
 					},
 					Port: prometheus.ServicePortName,


### PR DESCRIPTION
**How to categorize this PR?**

/area monitoring
/kind enhancement

**What this PR does / why we need it**:

This PR Federate apiserver_request_total metric to the aggregate prometheus instance

**Which issue(s) this PR fixes**:
Fixes #

**Special notes for your reviewer**:

**Release note**:

```other operator
Federate apiserver_request_total metric to the aggregate prometheus instance
```
